### PR TITLE
fix: updated download artifact action

### DIFF
--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -2,9 +2,12 @@ name: "CI/CD publish"
 
 on:
   workflow_run:
-    workflow: ["CI/CD pull request"]
-    branches: [ "main" ]
-    types: ["completed"]
+    workflow: 
+      - "CI/CD pull request"
+    branches: 
+      - "main"
+    types: 
+      - "completed"
 
 jobs:
   metadata:

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -1,8 +1,10 @@
 name: "CI/CD publish"
 
 on:
-  push:
+  workflow_run:
+    workflow: ["CI/CD pull request"]
     branches: [ "main" ]
+    types: ["completed"]
 
 jobs:
   metadata:
@@ -49,9 +51,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Download artefact"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.0
         with:
           name: notify-msteams-action-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
       - name: "Unzip artefact"
         run: |
           mkdir -p ./dist

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -2,7 +2,7 @@ name: "CI/CD publish"
 
 on:
   workflow_run:
-    workflow: [CI/CD pull request]
+    workflows: [CI/CD pull request]
     branches: [main]
     types: [completed]
 

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -2,9 +2,9 @@ name: "CI/CD publish"
 
 on:
   workflow_run:
-    workflows: [CI/CD pull request]
-    branches: [main]
-    types: [completed]
+    workflows: ["CI/CD pull request"]
+    branches: [ "main" ]
+    types: ["completed"]
 
 jobs:
   metadata:

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -2,12 +2,9 @@ name: "CI/CD publish"
 
 on:
   workflow_run:
-    workflow: 
-      - "CI/CD pull request"
-    branches: 
-      - "main"
-    types: 
-      - "completed"
+    workflow: [CI/CD pull request]
+    branches: [main]
+    types: [completed]
 
 jobs:
   metadata:

--- a/.github/workflows/stage-3-build.yaml
+++ b/.github/workflows/stage-3-build.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           make build
       - name: "Upload artefact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: notify-msteams-action-dist
           path: dist/


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updated the version of download artifact to v4 so that it can reference an artifact from another workflow. Upload artifact also needed to be on v4 for them both to work together

## Context

The pipeline won't work without the workflow being able to access the artifact from another workflow

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
